### PR TITLE
[run-tests] [fix][client] When the compressed message size exceeds maxMessageSize, the information in the InvalidMessageException may be incorrect

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -459,9 +459,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             int compressedSize = compressedPayload.readableBytes();
             if (compressedSize > ClientCnx.getMaxMessageSize() && !this.conf.isChunkingEnabled()) {
                 compressedPayload.release();
-                String compressedStr = (!isBatchMessagingEnabled() && conf.getCompressionType() != CompressionType.NONE)
-                                           ? "Compressed"
-                                           : "";
+                String compressedStr = conf.getCompressionType() != CompressionType.NONE ? "Compressed" : "";
                 PulsarClientException.InvalidMessageException invalidMessageException =
                         new PulsarClientException.InvalidMessageException(
                                 format("The producer %s of the topic %s sends a %s message with %d bytes that exceeds"


### PR DESCRIPTION
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/17910.

<!-- Before creating this PR, please ensure that the fork https://github.com/lordcheng10/pulsar is up to date with https://github.com/apache/pulsar -->