### PR TITLE
[branch-2.8][cherry-pick]  Cleanup state when lock revalidation gets LockBusyException

### DIFF
--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/coordination/impl/LockManagerImpl.java
@@ -106,7 +106,9 @@ class LockManagerImpl<T> implements LockManager<T> {
     private void handleSessionEvent(SessionEvent se) {
         if (se == SessionEvent.SessionReestablished) {
             log.info("Metadata store session has been re-established. Revalidating all the existing locks.");
-            locks.values().forEach(ResourceLockImpl::revalidate);
+            for (ResourceLockImpl<T> lock : locks.values()) {
+                lock.revalidate(true);
+            }
         } else if (se == SessionEvent.Reconnected) {
             log.info("Metadata store connection has been re-established. Revalidating locks that were pending.");
             locks.values().forEach(ResourceLockImpl::revalidateIfNeededAfterReconnection);


### PR DESCRIPTION
### Motivation
This PR is for running tests for upstream PR https://github.com/apache/pulsar/pull/19135

<!-- Before creating this PR, please ensure that the fork https://github.com/lordcheng10/pulsar is up to date with https://github.com/apache/pulsar -->

